### PR TITLE
fixed copy command, added canExecute

### DIFF
--- a/MVVM Example/View/MainWindow.xaml
+++ b/MVVM Example/View/MainWindow.xaml
@@ -55,13 +55,7 @@
         <StackPanel Grid.Row="2" Orientation="Horizontal">
             <Button Command="{Binding AddCommand}">+</Button>
             <Button Command="{Binding RemoveCommand}" CommandParameter="{Binding SelectedPhone}">-</Button>
-            <Button Content="2x">
-                <i:Interaction.Triggers>
-                    <i:EventTrigger EventName="MouseDoubleClick">
-                        <i:InvokeCommandAction Command="{Binding DoubleCommand}" CommandParameter="{Binding SelectedPhone}"/>
-                    </i:EventTrigger>
-                </i:Interaction.Triggers>
-            </Button>
+            <Button Command="{Binding CopyCommand}" CommandParameter="{Binding SelectedPhone}">Copy</Button>
         </StackPanel>
         
         <StackPanel Grid.Row="1" Grid.Column="1" DataContext="{Binding SelectedPhone}">

--- a/MVVM Example/ViewModel/ApplicationViewModel.cs
+++ b/MVVM Example/ViewModel/ApplicationViewModel.cs
@@ -175,7 +175,8 @@ namespace MVVM_Example.ViewModel
                                };
                                Phones.Insert(0, phoneCopy);
                            }
-                       }));
+                       },
+                       (obj) => !(SelectedPhone is null)));
             }
         }
 


### PR DESCRIPTION
`MouseDoubleClick` referenced a non-existing command, so I fixed it. Unfortunately the Interaction trigger had to be removed because it is not compatible with the canExecute method (AFAIK), and I couldn't find a good place for it.

If you would like to keep the original `InteractionTrigger` based implementation is up to you (with the correct command name of course), but I think this solution is more appropriate for such a basic example.